### PR TITLE
Optimize Header Parsing

### DIFF
--- a/parse.go
+++ b/parse.go
@@ -124,16 +124,16 @@ func Parse(v string) (GppContainer, []error) {
 // fastFailHeaderValidate performs quick validations of the header section before decoding
 // the bit stream.
 func fastFailHeaderValidate(h string) error {
-	// base64-url encodes 6 bits into each character. the first 6 bits of GPP header must always
-	// evaluate to the integer '3', so we can short cut by checking the first character directly.
-	if h[0] != SectionGPPByte {
-		return fmt.Errorf("error parsing GPP header, header must have type=%d", constants.SectionGPP)
-	}
-
 	// the GPP header must be at least 24 bits to represent the type, version, and a fibonacci sequence
 	// of at least 1 item. this requires at least 4 characters.
 	if len(h) < MinHeaderCharacters {
 		return fmt.Errorf("error parsing GPP header, should be at least %d bytes long", MinHeaderCharacters)
+	}
+
+	// base64-url encodes 6 bits into each character. the first 6 bits of GPP header must always
+	// evaluate to the integer '3', so we can short cut by checking the first character directly.
+	if h[0] != SectionGPPByte {
+		return fmt.Errorf("error parsing GPP header, header must have type=%d", constants.SectionGPP)
 	}
 
 	return nil

--- a/parse.go
+++ b/parse.go
@@ -37,7 +37,7 @@ func Parse(v string) (GppContainer, []error) {
 	sectionStrings := strings.Split(v, "~")
 
 	header := sectionStrings[0]
-	if err := fastFailHeaderValidate(header); err != nil {
+	if err := failFastHeaderValidate(header); err != nil {
 		return gpp, []error{err}
 	}
 
@@ -121,9 +121,9 @@ func Parse(v string) (GppContainer, []error) {
 	return gpp, errs
 }
 
-// fastFailHeaderValidate performs quick validations of the header section before decoding
+// failFastHeaderValidate performs quick validations of the header section before decoding
 // the bit stream.
-func fastFailHeaderValidate(h string) error {
+func failFastHeaderValidate(h string) error {
 	// the GPP header must be at least 24 bits to represent the type, version, and a fibonacci sequence
 	// of at least 1 item. this requires at least 4 characters.
 	if len(h) < MinHeaderCharacters {

--- a/parse.go
+++ b/parse.go
@@ -15,8 +15,8 @@ import (
 )
 
 const (
-	SectionGPPByte  byte = 'D'
-	MaxHeaderLength      = 3
+	SectionGPPByte      byte = 'D'
+	MinHeaderCharacters      = 4
 )
 
 type GppContainer struct {
@@ -36,20 +36,16 @@ func Parse(v string) (GppContainer, []error) {
 
 	sectionStrings := strings.Split(v, "~")
 
-	bs, err := util.NewBitStreamFromBase64(sectionStrings[0])
+	header := sectionStrings[0]
+	if err := fastFailHeaderValidate(header); err != nil {
+		return gpp, []error{err}
+	}
+
+	bs, err := util.NewBitStreamFromBase64(header)
 	if err != nil {
 		return gpp, []error{fmt.Errorf("error parsing GPP header, base64 decoding: %s", err)}
 	}
-	if bs.Len() < MaxHeaderLength {
-		return gpp, []error{fmt.Errorf("error parsing GPP header, should be at least %d bytes long", MaxHeaderLength)}
-	}
 
-	// base64 encoding codes just 6 bits into each byte. The first 6 bits of the header must always evaluate
-	// to the integer '3' as the GPP header type. Short cut the processing of a 6 bit integer with a simple
-	// byte comparison to shave off a few CPU cycles.
-	if sectionStrings[0][0] != SectionGPPByte {
-		return gpp, []error{fmt.Errorf("error parsing GPP header, header must have type=%d", constants.SectionGPP)}
-	}
 	// We checked the GPP header type above outside of the bitstream framework, so we advance the bit stream past the first 6 bits.
 	bs.SetPosition(6)
 
@@ -123,6 +119,24 @@ func Parse(v string) (GppContainer, []error) {
 	gpp.Sections = sections
 
 	return gpp, errs
+}
+
+// fastFailHeaderValidate performs quick validations of the header section before decoding
+// the bit stream.
+func fastFailHeaderValidate(h string) error {
+	// base64-url encodes 6 bits into each character. the first 6 bits of GPP header must always
+	// evaluate to the integer '3', so we can short cut by checking the first character directly.
+	if h[0] != SectionGPPByte {
+		return fmt.Errorf("error parsing GPP header, header must have type=%d", constants.SectionGPP)
+	}
+
+	// the GPP header must be at least 24 bits to represent the type, version, and a fibonacci sequence
+	// of at least 1 item. this requires at least 4 characters.
+	if len(h) < MinHeaderCharacters {
+		return fmt.Errorf("error parsing GPP header, should be at least %d bytes long", MinHeaderCharacters)
+	}
+
+	return nil
 }
 
 type GenericSection struct {

--- a/parse_test.go
+++ b/parse_test.go
@@ -165,17 +165,17 @@ func TestFailFastHeaderValidate(t *testing.T) {
 
 	t.Run("empty", func(t *testing.T) {
 		err := failFastHeaderValidate("")
-		assert.Error(t, err, "error parsing GPP header, should be at least 4 bytes long")
+		assert.EqualError(t, err, "error parsing GPP header, should be at least 4 bytes long")
 	})
 
 	t.Run("short", func(t *testing.T) {
 		err := failFastHeaderValidate("DB")
-		assert.Error(t, err, "error parsing GPP header, should be at least 4 bytes long")
+		assert.EqualError(t, err, "error parsing GPP header, should be at least 4 bytes long")
 	})
 
 	t.Run("invalid-type", func(t *testing.T) {
 		err := failFastHeaderValidate("AAAA")
-		assert.Error(t, err, "error parsing GPP header, should be at least 4 bytes long")
+		assert.EqualError(t, err, "error parsing GPP header, header must have type=3")
 	})
 }
 

--- a/parse_test.go
+++ b/parse_test.go
@@ -157,6 +157,28 @@ func TestParse(t *testing.T) {
 	}
 }
 
+func TestFailFastHeaderValidate(t *testing.T) {
+	t.Run("ok", func(t *testing.T) {
+		err := failFastHeaderValidate("DBABM")
+		assert.NoError(t, err)
+	})
+
+	t.Run("empty", func(t *testing.T) {
+		err := failFastHeaderValidate("")
+		assert.Error(t, err, "error parsing GPP header, should be at least 4 bytes long")
+	})
+
+	t.Run("short", func(t *testing.T) {
+		err := failFastHeaderValidate("DB")
+		assert.Error(t, err, "error parsing GPP header, should be at least 4 bytes long")
+	})
+
+	t.Run("invalid-type", func(t *testing.T) {
+		err := failFastHeaderValidate("AAAA")
+		assert.Error(t, err, "error parsing GPP header, should be at least 4 bytes long")
+	})
+}
+
 // go test -bench="^BenchmarkParse$" -benchmem .
 // BenchmarkParse-8          625084              1912 ns/op            1472 B/op         48 allocs/op (Apple M1 Pro)
 func BenchmarkParse(b *testing.B) {


### PR DESCRIPTION
When updating Prebid Server with the latest version of this library, I realized we check the base-64 stream before running quicker validation checks on the header. This PR changes the order of the checks to fail fast.